### PR TITLE
docs: enhance contributing document with releasing section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,7 @@ Please check if your PR fulfills the following requirements:
 - [ ] The commit message follows our guidelines: CONTRIBUTING.md#commit
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
+- [ ] The latest artifacts are committed (run `yarn build`)
 
 ## PR Type
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ yarn
 Build the typescript and package it for distribution
 
 ```bash
-yarn build && yarn package
+yarn build
 ```
 
 Run the tests :heavy_check_mark:
@@ -21,6 +21,62 @@ Run the tests :heavy_check_mark:
 ```bash
 yarn test
 ```
+
+Make sure you include the latest distribution built in your PR commits
+
+```bash
+yarn build && git add .
+```
+
+## Releasing a new version (for core contributors only)
+
+Always release from main
+
+```bash
+git fetch origin && git switch -C main origin/main
+```
+
+Generate the changelog, commit and tag of the release.
+
+```bash
+yarn release
+```
+
+Push the generated commit into `origin/main`
+
+```bash
+git push origin main
+```
+
+Push the generated version tag into `origin/main`.
+
+```bash
+git push --follow-tags origin main
+```
+
+This Github action follows the [recommended release workflow](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#recommendations)
+
+### Releasing minor and bath versions
+
+> NOTE: This operation may need multiple attempts. Always verify that the sha of the latest major version tag matches the latest commit in the main branch
+
+Match the major version release tag with the newly create release tag.
+
+```bash
+git tag -fa v3 -m "update v3 tag to v3.x.y"
+```
+
+Push the updated major version to force the release into the Github Marketplace
+
+```bash
+git push origin v1 --force
+```
+
+### Releasing a major version
+
+Go to create a new release in Github a follow the instructions [there](https://github.com/ngworker/angular-versions-action/releases/new).
+
+Use the major version format for the release. For example if the current major version tag is `v3` the new release version must be `v4`.
 
 ## <a name="rules"></a> Coding Rules
 
@@ -33,7 +89,7 @@ To ensure consistency throughout the source code, keep these rules in mind as yo
 
 We have very precise rules over how our git commit messages can be formatted. This leads to **more
 readable messages** that are easy to follow when looking through the **project history**. But also,
-we use the git commit messages to **generate the Lumberjack changelog**.
+we use the git commit messages to **generate the angular-versions-action changelog**.
 
 ### Commit Message Format
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ git push --follow-tags origin main
 
 This Github action follows the [recommended release workflow](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#recommendations)
 
-### Releasing minor and bath versions
+### Releasing minor and patch versions
 
 > NOTE: This operation may need multiple attempts. Always verify that the sha of the latest major version tag matches the latest commit in the main branch
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # GitHub Action - Match Angular Versions
 
-> DISCLAIMER: THIS ACTION IS HIGHLY EXPERIMENTAL.
-
 This GitHub Action (written in JavaScript) modifies the root `package.json` of a project and replaces the version of all **Angular** related dependencies for given base version.
 
 [![ngworker](https://img.shields.io/badge/ngworker-%40-red)](https://github.com/ngworker/)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

- The docs don't mention that the build distributions should be included in the PR.
- The releasing new versions section is missing from the CONTRIBUTING.md.

Issue Number: N/A

## What is the new behavior?

- The CONTRIBUTING.md includes info about how to release a new version of the action.
- The PR template now has a checklist item about including the latest distribution files.
- The Github Action is no longer described as Experimental (README.md)

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
